### PR TITLE
Add MQTT bridge and emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This monorepo contains a *minimal, production‑ready scaffold* for an AI‑driv
 | Service        | Tech           | Purpose                          |
 | -------------- | -------------- | -------------------------------- |
 | ingestion      | FastAPI + InfluxDB client | Streams raw battery telemetry |
+| mqtt_bridge    | FastAPI + MQTT client | Bridges MQTT telemetry to REST |
 | api_gateway    | FastAPI        | AuthN/Z & public REST API        |
 | ml_engine      | FastAPI + PyTorch | Hosts SoH & optimization models |
 
@@ -17,5 +18,9 @@ A React + TypeScript dashboard providing real‑time monitoring and control.
 **DevOps**
 
 Docker Compose for local dev, Kubernetes manifests for prod, GitHub Actions CI/CD pipeline, plus Prometheus/Grafana metrics stubs.
+
+## Telemetry Emulator
+
+`scripts/telemetry_emulator.py` publishes fake cell data over MQTT so integrators can run the stack locally via `docker-compose up`.
 
 > **Note**: Replace placeholder credentials, expand business logic, and harden security before going live.

--- a/backend/services/mqtt_bridge/Dockerfile
+++ b/backend/services/mqtt_bridge/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py ./
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/services/mqtt_bridge/main.py
+++ b/backend/services/mqtt_bridge/main.py
@@ -1,0 +1,58 @@
+import os
+import json
+import asyncio
+from pydantic import ValidationError
+from fastapi import FastAPI
+import httpx
+import paho.mqtt.client as mqtt
+from backend.common.schemas import Telemetry
+
+BROKER_URL = os.getenv("MQTT_BROKER", "mqtt")
+BROKER_PORT = int(os.getenv("MQTT_PORT", "1883"))
+TOPIC = os.getenv("MQTT_TOPIC", "telemetry/#")
+INGEST_URL = os.getenv("INGEST_URL", "http://ingestion:8000/ingest")
+JWT_TOKEN = os.getenv("JWT_TOKEN", "")
+
+app = FastAPI(title="MQTT Bridge")
+
+queue: asyncio.Queue = asyncio.Queue()
+
+# MQTT callbacks
+
+def on_connect(client, userdata, flags, rc):
+    client.subscribe(TOPIC)
+
+
+def on_message(client, userdata, msg):
+    try:
+        payload = json.loads(msg.payload.decode())
+        queue.put_nowait(payload)
+    except Exception:
+        pass
+
+
+async def worker():
+    async with httpx.AsyncClient() as session:
+        while True:
+            data = await queue.get()
+            try:
+                telem = Telemetry(**data)
+            except ValidationError:
+                continue
+            headers = {}
+            if JWT_TOKEN:
+                headers["Authorization"] = f"Bearer {JWT_TOKEN}"
+            await session.post(INGEST_URL, json=telem.dict(), headers=headers)
+            queue.task_done()
+
+
+@app.on_event("startup")
+async def startup_event():
+    loop = asyncio.get_event_loop()
+    loop.create_task(worker())
+    client = mqtt.Client()
+    client.on_connect = on_connect
+    client.on_message = on_message
+    client.connect(BROKER_URL, BROKER_PORT, 60)
+    loop.create_task(asyncio.to_thread(client.loop_forever))
+

--- a/backend/services/mqtt_bridge/requirements.txt
+++ b/backend/services/mqtt_bridge/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+paho-mqtt
+httpx
+pydantic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,14 @@ services:
   scheduler:
     build: ./backend/services/scheduler
     ports: ["8003:8000"]
+  mqtt:
+    image: eclipse-mosquitto:2
+    ports: ["1883:1883"]
+  mqtt_bridge:
+    build: ./backend/services/mqtt_bridge
+    environment:
+      - MQTT_BROKER=mqtt
+      - INGEST_URL=http://ingestion:8000/ingest
+    depends_on:
+      - mqtt
+      - ingestion

--- a/scripts/telemetry_emulator.py
+++ b/scripts/telemetry_emulator.py
@@ -1,0 +1,20 @@
+import json
+import os
+import time
+import random
+import paho.mqtt.publish as publish
+
+BROKER = os.getenv("MQTT_BROKER", "localhost")
+TOPIC = os.getenv("MQTT_TOPIC", "telemetry/device1")
+
+while True:
+    payload = {
+        "device_id": "device1",
+        "timestamp": time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+        "voltage": round(random.uniform(300, 350), 2),
+        "current": round(random.uniform(20, 40), 2),
+        "temperature": round(random.uniform(20, 40), 2),
+        "soc": round(random.uniform(50, 100), 2),
+    }
+    publish.single(TOPIC, json.dumps(payload), hostname=BROKER)
+    time.sleep(1)

--- a/tests/test_mqtt_bridge.py
+++ b/tests/test_mqtt_bridge.py
@@ -1,0 +1,14 @@
+from backend.common.schemas import Telemetry
+
+sample = {
+    "device_id": "d1",
+    "timestamp": "2023-01-01T00:00:00Z",
+    "voltage": 310.0,
+    "current": 25.0,
+    "temperature": 30.0,
+    "soc": 88.0,
+}
+
+def test_telemetry_schema():
+    t = Telemetry(**sample)
+    assert t.device_id == "d1"


### PR DESCRIPTION
## Summary
- add MQTT bridge microservice to push MQTT telemetry into the ingestion API
- include telemetry emulator script for local testing
- update docker-compose with Mosquitto broker and bridge service
- document new service and emulator in README
- add basic schema unit test

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe8b96f208329ba29398802cdc082